### PR TITLE
Use routing job binary for FRB saves

### DIFF
--- a/src/main/java/app/freerouting/core/BoardFileDetails.java
+++ b/src/main/java/app/freerouting/core/BoardFileDetails.java
@@ -108,6 +108,22 @@ public class BoardFileDetails implements Serializable
     return new ByteArrayInputStream(this.dataBytes);
   }
 
+  /**
+   * Writes the binary data of this object to the specified file.
+   */
+  public void writeDataToFile(File outputFile) throws IOException
+  {
+    if (outputFile == null)
+    {
+      return;
+    }
+
+    try (FileOutputStream fos = new FileOutputStream(outputFile))
+    {
+      fos.write(this.dataBytes);
+    }
+  }
+
   public void setData(byte[] data)
   {
     this.dataBytes = data;

--- a/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
+++ b/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
@@ -18,6 +18,7 @@ import app.freerouting.tests.BoardValidator;
 
 import java.awt.*;
 import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -389,6 +390,19 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread
       routingJob.finishedAt = Instant.now();
       routingJob.state = RoutingJobState.COMPLETED;
       globalSettings.statistics.incrementJobsCompleted();
+
+      if (routingJob.output.format == FileFormat.FRB)
+      {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(baos))
+        {
+          boardManager.saveAsBinary(oos);
+          routingJob.output.setData(baos.toByteArray());
+        } catch (Exception e)
+        {
+          routingJob.logError("Couldn't save the output into the job object.", e);
+        }
+      }
     }
 
     for (ThreadActionListener hl : this.listeners)

--- a/src/test/java/app/freerouting/tests/FrbSaveTest.java
+++ b/src/test/java/app/freerouting/tests/FrbSaveTest.java
@@ -1,0 +1,33 @@
+package app.freerouting.tests;
+
+import app.freerouting.core.BoardFileDetails;
+import app.freerouting.gui.FileFormat;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class FrbSaveTest {
+  @Test
+  void testRepeatedFrbSaveIsIdentical() throws Exception {
+    BoardFileDetails details = new BoardFileDetails();
+    details.format = FileFormat.FRB;
+    details.setFilename("test-output.frb");
+    byte[] data = new byte[] {1,2,3,4,5,6,7,8,9,0};
+    details.setData(data);
+
+    File temp = File.createTempFile("frbtest", ".frb");
+    temp.deleteOnExit();
+
+    details.writeDataToFile(temp);
+    byte[] first = Files.readAllBytes(temp.toPath());
+
+    // second save
+    details.writeDataToFile(temp);
+    byte[] second = Files.readAllBytes(temp.toPath());
+
+    assertArrayEquals(first, second, "FRB save should be stable");
+  }
+}


### PR DESCRIPTION
## Summary
- keep routing job binary data when saving FRB files
- expose helper to write binary data to file
- save FRB directly from job output
- retain FRB output after autorouting
- test that repeated FRB saves are identical

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies)*