### PR TITLE
Add TIMED_OUT task state

### DIFF
--- a/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
@@ -597,15 +597,21 @@ public class BatchAutorouter extends NamedAlgorithm
 
     bh.clear();
 
+    TaskState finalState;
     if (!this.is_interrupted)
     {
-      this.fireTaskStateChangedEvent(new TaskStateChangedEvent(this, TaskState.FINISHED, this.settings.get_start_pass_no(), this.board.get_hash()));
+      finalState = TaskState.FINISHED;
+    }
+    else if (job != null && job.state == RoutingJobState.TIMED_OUT)
+    {
+      finalState = TaskState.TIMED_OUT;
     }
     else
     {
-      // TODO: set it to TIMED_OUT if it was interrupted because of timeout
-      this.fireTaskStateChangedEvent(new TaskStateChangedEvent(this, TaskState.CANCELLED, this.settings.get_start_pass_no(), this.board.get_hash()));
+      finalState = TaskState.CANCELLED;
     }
+
+    this.fireTaskStateChangedEvent(new TaskStateChangedEvent(this, finalState, this.settings.get_start_pass_no(), this.board.get_hash()));
 
     return !this.is_interrupted;
   }

--- a/src/main/java/app/freerouting/autoroute/TaskState.java
+++ b/src/main/java/app/freerouting/autoroute/TaskState.java
@@ -2,5 +2,10 @@ package app.freerouting.autoroute;
 
 public enum TaskState
 {
-  IDLE, STARTED, RUNNING, FINISHED, CANCELLED, TIMED_OUT
+  IDLE,
+  STARTED,
+  RUNNING,
+  FINISHED,
+  CANCELLED,
+  TIMED_OUT
 }

--- a/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
+++ b/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
@@ -380,7 +380,11 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread
       routingJob.logError(e.getLocalizedMessage(), e);
     }
 
-    if (this.isStopRequested())
+    if (routingJob.state == RoutingJobState.TIMED_OUT)
+    {
+      routingJob.finishedAt = Instant.now();
+    }
+    else if (this.isStopRequested())
     {
       routingJob.finishedAt = Instant.now();
       routingJob.state = RoutingJobState.CANCELLED;
@@ -405,9 +409,18 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread
       }
     }
 
+    if (routingJob.state == RoutingJobState.TIMED_OUT)
+    {
+      FRAnalytics.autorouterTimedOut();
+    }
+
     for (ThreadActionListener hl : this.listeners)
     {
-      if (this.isStopRequested())
+      if (routingJob.state == RoutingJobState.TIMED_OUT)
+      {
+        hl.autorouterTimedOut();
+      }
+      else if (this.isStopRequested())
       {
         hl.autorouterAborted();
       }

--- a/src/main/java/app/freerouting/interactive/ThreadActionListener.java
+++ b/src/main/java/app/freerouting/interactive/ThreadActionListener.java
@@ -7,4 +7,8 @@ public interface ThreadActionListener
   void autorouterAborted();
 
   void autorouterFinished();
+
+  default void autorouterTimedOut()
+  {
+  }
 }

--- a/src/main/java/app/freerouting/management/analytics/FRAnalytics.java
+++ b/src/main/java/app/freerouting/management/analytics/FRAnalytics.java
@@ -326,6 +326,15 @@ public class FRAnalytics
     trackAnonymousAction(permanent_user_id, "Auto-router Finished", properties);
   }
 
+  public static void autorouterTimedOut()
+  {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("settings", GsonProvider.GSON.toJson(globalSettings));
+    properties.put("session_count", String.valueOf(sessionCount));
+
+    trackAnonymousAction(permanent_user_id, "Auto-router Timed Out", properties);
+  }
+
   public static void routeOptimizerStarted()
   {
     routeOptimizerStartedAt = Instant

--- a/src/test/java/app/freerouting/tests/TestBasedOnAnIssue.java
+++ b/src/test/java/app/freerouting/tests/TestBasedOnAnIssue.java
@@ -97,7 +97,7 @@ public class TestBasedOnAnIssue
     long startTime = System.currentTimeMillis();
     long timeoutInMillis = 5 * 60 * 1000; // 5 minutes in milliseconds
 
-    while ((job.state != RoutingJobState.COMPLETED) && (job.state != RoutingJobState.CANCELLED) && (job.state != RoutingJobState.TERMINATED))
+    while ((job.state != RoutingJobState.COMPLETED) && (job.state != RoutingJobState.CANCELLED) && (job.state != RoutingJobState.TIMED_OUT) && (job.state != RoutingJobState.TERMINATED))
     {
       try
       {


### PR DESCRIPTION
## Summary
- add new `TIMED_OUT` value to `TaskState`
- emit `TIMED_OUT` when a job timeout is detected
- notify listeners of timeout via new method
- track autorouter timeouts in analytics
- update test helper for timeout state

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve junit-jupiter due to no network)*