### PR TITLE
Expose ripup optimizer parameters

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -87,6 +87,11 @@ The primary way to configure Freerouting is through a JSON settings file. This f
 - **`start_ripup_costs`**: Cost factor for ripping up existing traces.
 - **`automatic_neckdown`**: Enables or disables automatic neckdown of traces.
 
+#### **`optimizer` Section**
+
+- **`initial_ripup_cost_factor`**: Multiplier applied to `start_ripup_costs` during the first optimization pass.
+- **`trace_ripup_reduction`**: Factor used to reduce rip-up costs when optimizing traces.
+
 #### **`usage_and_diagnostic_data` Section**
 
 - **`disable_analytics`**: Disables sending anonymous usage and diagnostic data.

--- a/src/main/java/app/freerouting/autoroute/BatchOptimizer.java
+++ b/src/main/java/app/freerouting/autoroute/BatchOptimizer.java
@@ -24,7 +24,6 @@ import java.util.TreeSet;
 public class BatchOptimizer extends NamedAlgorithm
 {
   protected static int MAX_AUTOROUTE_PASSES = 6;
-  protected static int ADDITIONAL_RIPUP_COST_FACTOR_AT_START = 10;
   protected ReadSortedRouteItems sorted_route_items;
   // in the first passes the ripup costs are increased for better performance.
   protected boolean use_increased_ripup_costs;
@@ -212,16 +211,14 @@ public class BatchOptimizer extends NamedAlgorithm
     int ripup_costs = this.settings.get_start_ripup_costs();
     if (this.use_increased_ripup_costs)
     {
-      // TODO: move this fixed parameter (ADDITIONAL_RIPUP_COST_FACTOR_AT_START=10) to the router optimizer settings
-      ripup_costs *= ADDITIONAL_RIPUP_COST_FACTOR_AT_START;
+      ripup_costs *= this.settings.optimizer.initialRipupCostFactor;
     }
 
     // reduce the ripup costs for traces
     if (p_item instanceof Trace)
     {
       // taking less ripup costs seems to produce better results
-      // TODO: move this fixed parameter (0.6) to the router optimizer settings
-      ripup_costs = (int) Math.round(0.6 * (double) ripup_costs);
+      ripup_costs = (int) Math.round(this.settings.optimizer.traceRipupReduction * (double) ripup_costs);
     }
 
     // route the connections

--- a/src/main/java/app/freerouting/settings/RouterOptimizerSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterOptimizerSettings.java
@@ -22,6 +22,16 @@ public class RouterOptimizerSettings implements Serializable
   public float optimizationImprovementThreshold = 0.01f;
   @SerializedName("parallel_router_instances")
   public int parallelAutorouterInstances = 1;
+  /**
+   * Additional ripup cost factor applied during the first optimization pass.
+   */
+  @SerializedName("initial_ripup_cost_factor")
+  public int initialRipupCostFactor = 10;
+  /**
+   * Reduction factor used when routing traces during optimization.
+   */
+  @SerializedName("trace_ripup_reduction")
+  public double traceRipupReduction = 0.6;
   public transient BoardUpdateStrategy boardUpdateStrategy = BoardUpdateStrategy.GREEDY;
   public transient String hybridRatio = "1:1";
   public transient ItemSelectionStrategy itemSelectionStrategy = ItemSelectionStrategy.PRIORITIZED;

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -152,6 +152,8 @@ public class RouterSettings implements Serializable
     result.maxPasses = this.maxPasses;
     result.optimizer.maxThreads = this.optimizer.maxThreads;
     result.optimizer.optimizationImprovementThreshold = this.optimizer.optimizationImprovementThreshold;
+    result.optimizer.initialRipupCostFactor = this.optimizer.initialRipupCostFactor;
+    result.optimizer.traceRipupReduction = this.optimizer.traceRipupReduction;
     result.optimizer.boardUpdateStrategy = this.optimizer.boardUpdateStrategy;
     result.optimizer.hybridRatio = this.optimizer.hybridRatio;
     result.optimizer.itemSelectionStrategy = this.optimizer.itemSelectionStrategy;

--- a/src/test/java/app/freerouting/tests/OptimizerRipupSettingsTest.java
+++ b/src/test/java/app/freerouting/tests/OptimizerRipupSettingsTest.java
@@ -1,0 +1,27 @@
+package app.freerouting.tests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class OptimizerRipupSettingsTest extends TestBasedOnAnIssue {
+  @Test
+  void test_ripup_settings_affect_routing() {
+    var job1 = GetRoutingJob("Issue029-hw48na.dsn");
+    job1.routerSettings.optimizer.enabled = true;
+    job1.routerSettings.optimizer.initialRipupCostFactor = 1;
+    job1.routerSettings.optimizer.traceRipupReduction = 1.0;
+    job1 = RunRoutingJob(job1, job1.routerSettings);
+    var stats1 = GetBoardStatistics(job1);
+
+    var job2 = GetRoutingJob("Issue029-hw48na.dsn");
+    job2.routerSettings.optimizer.enabled = true;
+    job2.routerSettings.optimizer.initialRipupCostFactor = 20;
+    job2.routerSettings.optimizer.traceRipupReduction = 0.3;
+    job2 = RunRoutingJob(job2, job2.routerSettings);
+    var stats2 = GetBoardStatistics(job2);
+
+    assertNotEquals(stats1.traces.totalLength, stats2.traces.totalLength,
+        "Different ripup settings should lead to different routing results");
+  }
+}


### PR DESCRIPTION
## Summary
- expose additional rip‑up tuning parameters in `RouterOptimizerSettings`
- respect those parameters inside `BatchOptimizer`
- document the new options in settings guide
- test that rip‑up behaviour changes when parameters are modified

## Testing
- `./gradlew test` *(fails: Could not resolve junit due to no network)*