### PR TITLE
Fix RoutingBoard gson serialization

### DIFF
--- a/src/main/java/app/freerouting/management/gson/GsonProvider.java
+++ b/src/main/java/app/freerouting/management/gson/GsonProvider.java
@@ -4,6 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.Strictness;
 
+import app.freerouting.board.RoutingBoard;
+import app.freerouting.management.gson.RoutingBoardTypeAdapter;
+
 import java.nio.file.Path;
 import java.time.Instant;
 
@@ -15,6 +18,7 @@ public class GsonProvider
       .registerTypeAdapter(Instant.class, new InstantTypeAdapter())
       .registerTypeAdapter(byte[].class, new ByteArrayToBase64TypeAdapter())
       .registerTypeAdapter(Path.class, new PathTypeAdapter())
+      .registerTypeAdapter(app.freerouting.board.RoutingBoard.class, new RoutingBoardTypeAdapter())
       .serializeNulls()
       .setStrictness(Strictness.LENIENT)
       .create();

--- a/src/main/java/app/freerouting/management/gson/RoutingBoardTypeAdapter.java
+++ b/src/main/java/app/freerouting/management/gson/RoutingBoardTypeAdapter.java
@@ -1,0 +1,52 @@
+package app.freerouting.management.gson;
+
+import app.freerouting.board.RoutingBoard;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.*;
+import java.util.Base64;
+
+/**
+ * Gson type adapter that serializes {@link RoutingBoard} using Java object serialization
+ * and encodes the binary data as base64. This allows RoutingBoard instances to be
+ * safely written to JSON and restored later.
+ */
+public class RoutingBoardTypeAdapter extends TypeAdapter<RoutingBoard>
+{
+  @Override
+  public void write(JsonWriter out, RoutingBoard value) throws IOException
+  {
+    if (value == null)
+    {
+      out.nullValue();
+      return;
+    }
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos))
+    {
+      oos.writeObject(value);
+    }
+    out.value(Base64.getEncoder().encodeToString(baos.toByteArray()));
+  }
+
+  @Override
+  public RoutingBoard read(JsonReader in) throws IOException
+  {
+    if (in.peek() == JsonToken.NULL)
+    {
+      in.nextNull();
+      return null;
+    }
+    byte[] data = Base64.getDecoder().decode(in.nextString());
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data)))
+    {
+      return (RoutingBoard) ois.readObject();
+    } catch (ClassNotFoundException e)
+    {
+      throw new IOException(e);
+    }
+  }
+}

--- a/src/test/java/app/freerouting/tests/RoutingBoardSerializationTest.java
+++ b/src/test/java/app/freerouting/tests/RoutingBoardSerializationTest.java
@@ -1,0 +1,88 @@
+package app.freerouting.tests;
+
+import app.freerouting.autoroute.NamedAlgorithm;
+import app.freerouting.autoroute.NamedAlgorithmType;
+import app.freerouting.board.*;
+import app.freerouting.core.StoppableThread;
+import app.freerouting.management.gson.GsonProvider;
+import app.freerouting.rules.BoardRules;
+import app.freerouting.rules.ClearanceMatrix;
+import app.freerouting.settings.RouterSettings;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RoutingBoardSerializationTest
+{
+  private RoutingBoard createBoard()
+  {
+    Layer[] layers = new Layer[] { new Layer("top", true), new Layer("bottom", true) };
+    LayerStructure layerStructure = new LayerStructure(layers);
+    ClearanceMatrix cm = ClearanceMatrix.get_default_instance(layerStructure, 0);
+    BoardRules rules = new BoardRules(layerStructure, cm);
+    IntBox bbox = new IntBox(0, 0, 1000, 1000);
+    PolygonShape outline = new PolygonShape(new Polygon(new Point[] {
+        new IntPoint(0,0), new IntPoint(1000,0), new IntPoint(1000,1000), new IntPoint(0,1000), new IntPoint(0,0)
+    }));
+    return new RoutingBoard(bbox, layerStructure, new PolylineShape[] { outline }, BoardRules.default_clearance_class(), rules, new Communication());
+  }
+
+  @Test
+  void testRoutingBoardGsonRoundTrip() throws Exception
+  {
+    Gson gson = GsonProvider.GSON;
+    RoutingBoard board = createBoard();
+
+    String json = gson.toJson(board);
+    RoutingBoard restored = gson.fromJson(json, RoutingBoard.class);
+
+    assertNotNull(restored);
+    assertEquals(board.get_layer_count(), restored.get_layer_count());
+    assertEquals(board.bounding_box.ll.x, restored.bounding_box.ll.x);
+  }
+
+  private static class DummyThread extends StoppableThread
+  {
+    @Override
+    protected void thread_action() {}
+  }
+
+  private static class DummyAlgorithm extends NamedAlgorithm
+  {
+    DummyAlgorithm(RoutingBoard board)
+    {
+      super(new DummyThread(), board, new RouterSettings());
+    }
+
+    @Override
+    protected String getId() { return "dummy"; }
+
+    @Override
+    protected String getName() { return "dummy"; }
+
+    @Override
+    protected String getVersion() { return "1.0"; }
+
+    @Override
+    protected String getDescription() { return ""; }
+
+    @Override
+    protected NamedAlgorithmType getType() { return NamedAlgorithmType.ROUTER; }
+  }
+
+  @Test
+  void testAlgorithmSerializationRoundTrip() throws Exception
+  {
+    Gson gson = GsonProvider.GSON;
+    RoutingBoard board = createBoard();
+    DummyAlgorithm algo = new DummyAlgorithm(board);
+
+    String json = gson.toJson(algo);
+    DummyAlgorithm restored = gson.fromJson(json, DummyAlgorithm.class);
+
+    assertNotNull(restored);
+    assertNotNull(restored.board);
+    assertEquals(board.get_layer_count(), restored.board.get_layer_count());
+  }
+}


### PR DESCRIPTION
## Summary
- add `RoutingBoardTypeAdapter` for custom gson serialisation
- register adapter in `GsonProvider`
- test gson round‑trip for `RoutingBoard` and for algorithms

## Testing
- `./gradlew test --quiet` *(fails: Could not resolve junit-jupiter)*