### PR TITLE
Clarify stop flags and add interruption tests

### DIFF
--- a/src/main/java/app/freerouting/core/StoppableThread.java
+++ b/src/main/java/app/freerouting/core/StoppableThread.java
@@ -7,8 +7,17 @@ import app.freerouting.datastructures.Stoppable;
  */
 public abstract class StoppableThread extends Thread implements Stoppable
 {
+  /**
+   * Indicates that the entire routing job should stop. When this flag is set the
+   * autorouter as well as any subsequent optimizer passes will be aborted.
+   */
   private boolean stop_requested = false;
-  // TODO: why do we need this, can't we use stop_requested?
+
+  /**
+   * Indicates that only the autorouter should be aborted. The optimizer is still
+   * allowed to continue running. {@code stop_requested} implies this flag but it
+   * can be set independently when only the autorouter needs to stop.
+   */
   private boolean stop_auto_router = false;
 
   /**
@@ -26,7 +35,7 @@ public abstract class StoppableThread extends Thread implements Stoppable
     thread_action();
   }
 
-  // Request the thread to stop including the fanout, auto-router and optimizer tasks
+  // Request the thread to stop including the fanout, autorouter and optimizer tasks
   @Override
   public synchronized void requestStop()
   {
@@ -40,13 +49,18 @@ public abstract class StoppableThread extends Thread implements Stoppable
     return stop_requested;
   }
 
-  // Request the thread to stop the auto-router, but continue with the optimizer and other tasks
+  /**
+   * Request the thread to stop only the autorouter. The optimizer and other
+   * tasks are allowed to continue.
+   */
   public synchronized void request_stop_auto_router()
   {
     stop_auto_router = true;
   }
 
-  // Check if the thread should stop the auto router
+  /**
+   * Returns {@code true} if the autorouter should be aborted.
+   */
   public synchronized boolean is_stop_auto_router_requested()
   {
     return stop_auto_router;

--- a/src/test/java/app/freerouting/tests/StopFlagsTest.java
+++ b/src/test/java/app/freerouting/tests/StopFlagsTest.java
@@ -1,0 +1,47 @@
+package app.freerouting.tests;
+
+import app.freerouting.core.RoutingJob;
+import app.freerouting.core.RoutingJobState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StopFlagsTest extends TestBasedOnAnIssue {
+  @Test
+  void test_autorouter_stop_only() throws Exception {
+    RoutingJob job = GetRoutingJob("Issue026-J2_reference.dsn");
+    job.routerSettings.optimizer.enabled = true;
+
+    scheduler.enqueueJob(job);
+    job.state = RoutingJobState.READY_TO_START;
+
+    while (job.thread == null) {
+      Thread.sleep(50);
+    }
+    Thread.sleep(200);
+    job.thread.request_stop_auto_router();
+
+    job = RunRoutingJob(job, job.routerSettings);
+    assertEquals(RoutingJobState.COMPLETED, job.state, "Job should finish when only the autorouter is stopped");
+    assertNotNull(GetBoardStatistics(job));
+  }
+
+  @Test
+  void test_request_stop_cancels_job() throws Exception {
+    RoutingJob job = GetRoutingJob("Issue026-J2_reference.dsn");
+    job.routerSettings.setRunRouter(false);
+    job.routerSettings.optimizer.enabled = true;
+
+    scheduler.enqueueJob(job);
+    job.state = RoutingJobState.READY_TO_START;
+
+    while (job.thread == null) {
+      Thread.sleep(50);
+    }
+    Thread.sleep(200);
+    job.thread.requestStop();
+
+    job = RunRoutingJob(job, job.routerSettings);
+    assertEquals(RoutingJobState.CANCELLED, job.state, "Job should be cancelled when stop is requested");
+  }
+}


### PR DESCRIPTION
## Summary
- document semantics of `stop_requested` vs `stop_auto_router`
- test autorouter stop and full stop flags

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies)*