### PR TITLE
Implement email-based authentication lookup

### DIFF
--- a/src/integrationTest/java/app/freerouting/api/AuthenticationIntegrationTest.java
+++ b/src/integrationTest/java/app/freerouting/api/AuthenticationIntegrationTest.java
@@ -1,0 +1,86 @@
+package app.freerouting.api;
+
+import app.freerouting.Freerouting;
+import app.freerouting.settings.GlobalSettings;
+import com.sun.net.httpserver.HttpServer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AuthenticationIntegrationTest {
+  private Server apiServer;
+  private HttpServer authServer;
+  private int port;
+  private UUID resolvedId;
+
+  @BeforeAll
+  void setup() throws Exception {
+    // start mock auth server
+    resolvedId = UUID.randomUUID();
+    authServer = HttpServer.create(new InetSocketAddress(0), 0);
+    authServer.createContext("/resolve", exchange -> {
+      String response = "{\"id\":\"" + resolvedId + "\"}";
+      exchange.sendResponseHeaders(200, response.getBytes().length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(response.getBytes());
+      }
+    });
+    authServer.createContext("/validate", exchange -> {
+      exchange.sendResponseHeaders(200, -1);
+      exchange.close();
+    });
+    authServer.start();
+
+    GlobalSettings gs = new GlobalSettings();
+    gs.apiServerSettings.isEnabled = true;
+    gs.apiServerSettings.isHttpAllowed = true;
+    gs.apiServerSettings.endpoints = new String[]{"http://localhost:0"};
+    gs.authServiceSettings.endpoint = "http://localhost:" + authServer.getAddress().getPort();
+    Freerouting.globalSettings = gs;
+
+    apiServer = Freerouting.InitializeAPI(gs.apiServerSettings);
+    Thread.sleep(500);
+    port = ((ServerConnector) apiServer.getConnectors()[0]).getLocalPort();
+  }
+
+  @AfterAll
+  void tearDown() throws Exception {
+    if (apiServer != null) {
+      apiServer.stop();
+    }
+    if (authServer != null) {
+      authServer.stop(0);
+    }
+  }
+
+  @Test
+  void authenticatedRequest() throws Exception {
+    HttpRequest req = HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:" + port + "/v1/sessions/list"))
+        .header("Freerouting-Profile-Email", "test@example.com")
+        .build();
+    HttpResponse<String> resp = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, resp.statusCode());
+  }
+
+  @Test
+  void unauthenticatedRequest() throws Exception {
+    HttpRequest req = HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:" + port + "/v1/sessions/list"))
+        .build();
+    HttpResponse<String> resp = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+    assertEquals(401, resp.statusCode());
+  }
+}

--- a/src/main/java/app/freerouting/api/ApiExceptionMapper.java
+++ b/src/main/java/app/freerouting/api/ApiExceptionMapper.java
@@ -16,6 +16,10 @@ public class ApiExceptionMapper implements ExceptionMapper<Throwable>
   @Produces(MediaType.APPLICATION_JSON)
   public Response toResponse(Throwable exception)
   {
+    if (exception instanceof jakarta.ws.rs.WebApplicationException wae)
+    {
+      return wae.getResponse();
+    }
     JsonObject errorMessage = new JsonObject();
     errorMessage.addProperty("error", exception.getMessage());
     errorMessage.addProperty("documentation", "https://github.com/freerouting/freerouting/blob/master/docs/API_v1.md");

--- a/src/main/java/app/freerouting/management/authentication/AuthenticationService.java
+++ b/src/main/java/app/freerouting/management/authentication/AuthenticationService.java
@@ -1,0 +1,69 @@
+package app.freerouting.management.authentication;
+
+import app.freerouting.logger.FRLogger;
+import app.freerouting.management.gson.GsonProvider;
+import com.google.gson.JsonObject;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+
+/**
+ * Simple client for the Freerouting authentication service.
+ */
+public class AuthenticationService {
+  private final String endpoint;
+
+  public AuthenticationService(String endpoint) {
+    this.endpoint = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+  }
+
+  /**
+   * Resolve a user id from an e-mail address.
+   */
+  public UUID resolveUserId(String email) {
+    try {
+      String url = endpoint + "/resolve?email=" + URLEncoder.encode(email, StandardCharsets.UTF_8);
+      HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+      HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() == 200) {
+        JsonObject obj = GsonProvider.GSON.fromJson(response.body(), JsonObject.class);
+        if (obj.has("id")) {
+          return UUID.fromString(obj.get("id").getAsString());
+        }
+      }
+    } catch (Exception e) {
+      FRLogger.error("Failed to resolve user id: " + e.getMessage(), e);
+    }
+    return null;
+  }
+
+  /**
+   * Validate that the given user exists.
+   */
+  public boolean validateUser(UUID userId, String email) {
+    try {
+      JsonObject payload = new JsonObject();
+      if (userId != null) {
+        payload.addProperty("id", userId.toString());
+      }
+      if (email != null && !email.isEmpty()) {
+        payload.addProperty("email", email);
+      }
+      HttpRequest request = HttpRequest.newBuilder()
+          .uri(URI.create(endpoint + "/validate"))
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString(GsonProvider.GSON.toJson(payload)))
+          .build();
+      HttpResponse<Void> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
+      return response.statusCode() == 200;
+    } catch (Exception e) {
+      FRLogger.error("Failed to validate user: " + e.getMessage(), e);
+      return false;
+    }
+  }
+}

--- a/src/main/java/app/freerouting/settings/AuthenticationServiceSettings.java
+++ b/src/main/java/app/freerouting/settings/AuthenticationServiceSettings.java
@@ -1,0 +1,10 @@
+package app.freerouting.settings;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+public class AuthenticationServiceSettings implements Serializable {
+  @SerializedName("endpoint")
+  public String endpoint = "http://localhost:37865";
+}

--- a/src/main/java/app/freerouting/settings/GlobalSettings.java
+++ b/src/main/java/app/freerouting/settings/GlobalSettings.java
@@ -38,6 +38,8 @@ public class GlobalSettings implements Serializable
   public final FeatureFlagsSettings featureFlags = new FeatureFlagsSettings();
   @SerializedName("api_server")
   public final ApiServerSettings apiServerSettings = new ApiServerSettings();
+  @SerializedName("auth_service")
+  public final AuthenticationServiceSettings authServiceSettings = new AuthenticationServiceSettings();
   @SerializedName("statistics")
   public final StatisticsSettings statistics = new StatisticsSettings();
   private final transient String[] supportedLanguages = {


### PR DESCRIPTION
## Summary
- add `AuthenticationService` client
- allow configure auth service endpoint in `GlobalSettings`
- resolve and validate users via auth service in `BaseController`
- return proper HTTP codes from `ApiExceptionMapper`
- cover authenticated and unauthenticated requests in new integration tests

## Testing
- `./gradlew test` *(fails: Could not resolve JUnit from Maven Central)*