### PR TITLE
Add batched BigQuery analytics queue

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -34,7 +34,9 @@ The primary way to configure Freerouting is through a JSON settings file. This f
   },
   "usage_and_diagnostic_data": {
     "disable_analytics": false,
-    "analytics_modulo": 16
+    "analytics_modulo": 16,
+    "analytics_flush_interval": 30,
+    "analytics_batch_size": 20
   },
   "feature_flags": {
     "logging": true,
@@ -96,6 +98,8 @@ The primary way to configure Freerouting is through a JSON settings file. This f
 
 - **`disable_analytics`**: Disables sending anonymous usage and diagnostic data.
 - **`analytics_modulo`**: Sends usage data after every Nth run, where N is the value of `analytics_modulo`.
+- **`analytics_flush_interval`**: Seconds between flushing queued analytics events to BigQuery.
+- **`analytics_batch_size`**: Number of events sent in each BigQuery batch.
 
 #### **`feature_flags` Section**
 

--- a/src/main/java/app/freerouting/api/v1/AnalyticsControllerV1.java
+++ b/src/main/java/app/freerouting/api/v1/AnalyticsControllerV1.java
@@ -15,6 +15,7 @@ import static app.freerouting.management.gson.GsonProvider.GSON;
 @Path("/v1/analytics")
 public class AnalyticsControllerV1
 {
+  private static BigQueryClient client;
   /**
    * Tracks an action performed by a user.
    *
@@ -45,11 +46,16 @@ public class AnalyticsControllerV1
 
     try
     {
-      // TODO: implement some caching mechanism, and insert the cached items in a batch
+      if (client == null)
+      {
+        client = new BigQueryClient(
+            Constants.FREEROUTING_VERSION,
+            globalSettings.usageAndDiagnosticData.bigqueryServiceAccountKey,
+            globalSettings.usageAndDiagnosticData.analyticsFlushInterval,
+            globalSettings.usageAndDiagnosticData.analyticsBatchSize);
+      }
 
-      // Send the payload to the BigQuery analytics service
-      var bigqueryClient = new BigQueryClient(Constants.FREEROUTING_VERSION, globalSettings.usageAndDiagnosticData.bigqueryServiceAccountKey);
-      bigqueryClient.track(trackPayload.userId, trackPayload.anonymousId, trackPayload.event, trackPayload.properties);
+      client.track(trackPayload.userId, trackPayload.anonymousId, trackPayload.event, trackPayload.properties);
     } catch (Exception e)
     {
       return Response

--- a/src/main/java/app/freerouting/settings/UsageAndDiagnosticDataSettings.java
+++ b/src/main/java/app/freerouting/settings/UsageAndDiagnosticDataSettings.java
@@ -15,4 +15,8 @@ public class UsageAndDiagnosticDataSettings implements Serializable
   public transient String bigqueryServiceAccountKey = null;
   @SerializedName("logger_key")
   public transient String loggerKey = TextManager.generateRandomAlphanumericString(32);
+  @SerializedName("analytics_flush_interval")
+  public int analyticsFlushInterval = 30; // seconds
+  @SerializedName("analytics_batch_size")
+  public int analyticsBatchSize = 20;
 }


### PR DESCRIPTION
## Summary
- implement a thread-safe queue in `BigQueryClient` and batch flush events
- configure flush interval and batch size via `UsageAndDiagnosticDataSettings`
- reuse a singleton BigQuery client in `AnalyticsControllerV1`
- document analytics batching settings

## Testing
- `./gradlew test` *(fails: Could not download JUnit due to no network access)*